### PR TITLE
kwin: Fix building on aarch64-linux

### DIFF
--- a/pkgs/desktops/plasma-5/kwin/0001-Revert-x11-Refactor-output-updates.patch
+++ b/pkgs/desktops/plasma-5/kwin/0001-Revert-x11-Refactor-output-updates.patch
@@ -1,0 +1,153 @@
+From 84f020835e3624342a928aae68e62e636bf2cc8c Mon Sep 17 00:00:00 2001
+From: Yuriy Taraday <yorik.sar@gmail.com>
+Date: Wed, 12 Oct 2022 12:07:23 +0400
+Subject: [PATCH] Revert "[x11] Refactor output updates"
+
+This reverts commit 9a34ebbffc791cbeadc9abafda793ebee654b270.
+
+This should fix compilation with older GCC.
+---
+ CMakeLists.txt                                |  2 +-
+ .../standalone/x11_standalone_platform.cpp    | 63 +++++++++++--------
+ 2 files changed, 38 insertions(+), 27 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 3e7bf700e..6ff24aa5c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,7 +70,7 @@ add_definitions(-DMESA_EGL_NO_X11_HEADERS)
+ add_definitions(-DEGL_NO_X11)
+ add_definitions(-DEGL_NO_PLATFORM_SPECIFIC_TYPES)
+ 
+-set(CMAKE_CXX_STANDARD 20)
++set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ 
+ # required frameworks by Core
+diff --git a/src/backends/x11/standalone/x11_standalone_platform.cpp b/src/backends/x11/standalone/x11_standalone_platform.cpp
+index 498d5cbe3..ac0f732b2 100644
+--- a/src/backends/x11/standalone/x11_standalone_platform.cpp
++++ b/src/backends/x11/standalone/x11_standalone_platform.cpp
+@@ -54,8 +54,6 @@
+ #include <QX11Info>
+ #endif
+ 
+-#include <span>
+-
+ namespace KWin
+ {
+ 
+@@ -407,7 +405,8 @@ void X11StandalonePlatform::invertScreen()
+         ScreenResources res((active_client && active_client->window() != XCB_WINDOW_NONE) ? active_client->window() : rootWindow());
+ 
+         if (!res.isNull()) {
+-            for (auto crtc : std::span(res.crtcs(), res->num_crtcs)) {
++            for (int j = 0; j < res->num_crtcs; ++j) {
++                auto crtc = res.crtcs()[j];
+                 CrtcGamma gamma(crtc);
+                 if (gamma.isNull()) {
+                     continue;
+@@ -480,39 +479,54 @@ void X11StandalonePlatform::doUpdateOutputs()
+     if (Xcb::Extensions::self()->isRandrAvailable()) {
+         T resources(rootWindow());
+         if (!resources.isNull()) {
++            xcb_randr_crtc_t *crtcs = resources.crtcs();
++            const xcb_randr_mode_info_t *modes = resources.modes();
++
++            QVector<Xcb::RandR::CrtcInfo> infos(resources->num_crtcs);
++            for (int i = 0; i < resources->num_crtcs; ++i) {
++                infos[i] = Xcb::RandR::CrtcInfo(crtcs[i], resources->config_timestamp);
++            }
+ 
+-            std::span crtcs(resources.crtcs(), resources->num_crtcs);
+-            for (auto crtc : crtcs) {
+-                Xcb::RandR::CrtcInfo info(crtc, resources->config_timestamp);
++            for (int i = 0; i < resources->num_crtcs; ++i) {
++                Xcb::RandR::CrtcInfo info(infos.at(i));
+ 
+                 const QRect geometry = info.rect();
+                 if (!geometry.isValid()) {
+                     continue;
+                 }
+ 
+-                float refreshRate = -1.0f;
++                xcb_randr_output_t *outputs = info.outputs();
++                QVector<Xcb::RandR::OutputInfo> outputInfos(outputs ? resources->num_outputs : 0);
++                QVector<Xcb::RandR::OutputProperty> edids(outputs ? resources->num_outputs : 0);
++                if (outputs) {
++                    for (int i = 0; i < resources->num_outputs; ++i) {
++                        outputInfos[i] = Xcb::RandR::OutputInfo(outputs[i], resources->config_timestamp);
++                        edids[i] = Xcb::RandR::OutputProperty(outputs[i], atoms->edid, XCB_ATOM_INTEGER, 0, 100, false, false);
++                    }
++                }
+ 
+-                for (auto mode : std::span(resources.modes(), resources->num_modes)) {
+-                    if (info->mode == mode.id) {
+-                        if (mode.htotal != 0 && mode.vtotal != 0) { // BUG 313996
++                float refreshRate = -1.0f;
++                for (int j = 0; j < resources->num_modes; ++j) {
++                    if (info->mode == modes[j].id) {
++                        if (modes[j].htotal != 0 && modes[j].vtotal != 0) { // BUG 313996
+                             // refresh rate calculation - WTF was wikipedia 1998 when I needed it?
+-                            int dotclock = mode.dot_clock,
+-                                vtotal = mode.vtotal;
+-                            if (mode.mode_flags & XCB_RANDR_MODE_FLAG_INTERLACE) {
++                            int dotclock = modes[j].dot_clock,
++                                vtotal = modes[j].vtotal;
++                            if (modes[j].mode_flags & XCB_RANDR_MODE_FLAG_INTERLACE) {
+                                 dotclock *= 2;
+                             }
+-                            if (mode.mode_flags & XCB_RANDR_MODE_FLAG_DOUBLE_SCAN) {
++                            if (modes[j].mode_flags & XCB_RANDR_MODE_FLAG_DOUBLE_SCAN) {
+                                 vtotal *= 2;
+                             }
+-                            refreshRate = dotclock / float(mode.htotal * vtotal);
++                            refreshRate = dotclock / float(modes[j].htotal * vtotal);
+                         }
+                         break; // found mode
+                     }
+                 }
+ 
+-                for (auto xcbOutput : std::span(info.outputs(), info->num_outputs)) {
+-                    Xcb::RandR::OutputInfo outputInfo(xcbOutput, resources->config_timestamp);
+-                    if (outputInfo->crtc != crtc) {
++                for (int j = 0; j < info->num_outputs; ++j) {
++                    Xcb::RandR::OutputInfo outputInfo(outputInfos.at(j));
++                    if (outputInfo->crtc != crtcs[i]) {
+                         continue;
+                     }
+ 
+@@ -528,14 +542,12 @@ void X11StandalonePlatform::doUpdateOutputs()
+                     // TODO: Perhaps the output has to save the inherited gamma ramp and
+                     // restore it during tear down. Currently neither standalone x11 nor
+                     // drm platform do this.
+-                    Xcb::RandR::CrtcGamma gamma(crtc);
++                    Xcb::RandR::CrtcGamma gamma(crtcs[i]);
+ 
+                     output->setRenderLoop(m_renderLoop.get());
+-                    output->setCrtc(crtc);
++                    output->setCrtc(crtcs[i]);
+                     output->setGammaRampSize(gamma.isNull() ? 0 : gamma->size);
+-                    auto it = std::find(crtcs.begin(), crtcs.end(), crtc);
+-                    int crtcIndex = std::distance(crtcs.begin(), it);
+-                    output->setXineramaNumber(crtcIndex);
++                    output->setXineramaNumber(i);
+ 
+                     QSize physicalSize(outputInfo->mm_width, outputInfo->mm_height);
+                     switch (info->rotation) {
+@@ -556,10 +568,9 @@ void X11StandalonePlatform::doUpdateOutputs()
+                         .physicalSize = physicalSize,
+                     };
+ 
+-                    auto edidProperty = Xcb::RandR::OutputProperty(xcbOutput, atoms->edid, XCB_ATOM_INTEGER, 0, 100, false, false);
+                     bool ok;
+-                    if (auto data = edidProperty.toByteArray(&ok); ok && !data.isEmpty()) {
+-                        if (auto edid = Edid(data, edidProperty.data()->num_items); edid.isValid()) {
++                    if (auto data = edids[j].toByteArray(&ok); ok && !data.isEmpty()) {
++                        if (auto edid = Edid(data, edids[j].data()->num_items); edid.isValid()) {
+                             information.manufacturer = edid.manufacturerString();
+                             information.model = edid.monitorName();
+                             information.serialNumber = edid.serialNumber();
+-- 
+2.37.2
+

--- a/pkgs/desktops/plasma-5/kwin/default.nix
+++ b/pkgs/desktops/plasma-5/kwin/default.nix
@@ -1,4 +1,5 @@
 { mkDerivation
+, stdenv
 , lib
 , extra-cmake-modules
 , kdoctools
@@ -141,6 +142,8 @@ mkDerivation {
       url = "https://invent.kde.org/plasma/kwin/-/commit/9a008b223ad696db3bf5692750f2b74e578e08b8.diff";
       sha256 = "sha256-f35G+g2MVABLDbAkCed3ZmtDWrzYn1rdD08mEx35j4k=";
     })
+  ] ++ lib.optionals stdenv.isAarch64 [
+    ./0001-Revert-x11-Refactor-output-updates.patch
   ];
   CXXFLAGS = [
     ''-DNIXPKGS_XWAYLAND=\"${lib.getBin xwayland}/bin/Xwayland\"''


### PR DESCRIPTION
Revert this commit to avoid dependency on <span> that is not providede by GCC 9 that we currently use on aarch64:

https://invent.kde.org/plasma/kwin/-/commit/9a34ebbffc791cbeadc9abafda793ebee654b270

Part of NixOS/nixpkgs#191357